### PR TITLE
Wrap the ports set in sorted

### DIFF
--- a/aclhound/aclsemantics.py
+++ b/aclhound/aclsemantics.py
@@ -227,7 +227,7 @@ class grammarSemantics(object):
                 low, high = atom['range']
                 ports = ports + range(low, high + 1)
         # sort and deduplicate all ports
-        ports = set(ports)
+        ports = sorted(set(ports))
         # create the smallest amount of port ranges possible
         atoms = []
         for a, b in itertools.groupby(enumerate(ports), lambda(x, y): y - x):


### PR DESCRIPTION
A set() does deduplicate the objects in the list but the sorting is based on the hashed value. The order is not guaranteed when the integer crosses bit size boundaries.

```
print set([32761,32762,32768])
set([32768, 32761, 32762])

print sorted(set([32761,32762,32768]))
[32761, 32762, 32768]
```