### PR TITLE
Fix test docs and feedback

### DIFF
--- a/INSTALL-CONFIG.md
+++ b/INSTALL-CONFIG.md
@@ -28,7 +28,7 @@ Notes:
  This can be found in the /etc/aclhound/ directory.
 
  This configuration file is used to configure some base settings for aclhound itself, and
- it contains settings to talke with jenkins &amp; gerrit.
+ it contains settings to talk with jenkins &amp; gerrit.
 
  The following is an example configuration file:
 <pre>
@@ -82,7 +82,7 @@ has the ACLHound software installed, and type:
 
  &quot;aclhound init&quot;
 
-This little setup part of ACLHound asks you 3 questions: username, location and wether or
+This little setup part of ACLHound asks you 3 questions: username, location and whether or
 not you'd like to clone the repository data (configured in the aclhound.conf)
 
 ## **Jenkins integration**

--- a/INSTALL-CONFIG.md
+++ b/INSTALL-CONFIG.md
@@ -6,8 +6,8 @@ To install the package, execute the following lines on the commandline:
 <pre>
 git clone https://github.com/job/aclhound.git
 cd aclhound
-virtualenv .
-source ./bin/activate
+virtualenv venv
+source venv/bin/activate
 pip install -r requirements.txt
 make test
 python setup.py install

--- a/INSTALL-CONFIG.md
+++ b/INSTALL-CONFIG.md
@@ -9,9 +9,17 @@ cd aclhound
 virtualenv venv
 source venv/bin/activate
 pip install -r requirements.txt
+sudo python setup.py install
+sudo cp /etc/aclhound/aclhound.conf.dist /etc/aclhound/aclhound.conf
+aclhound init
 make test
-python setup.py install
 </pre>
+
+Notes:
+
+* `setup.py` is run with sudo as it writes to `/etc/`
+* `aclhound init` creates the `~/.aclhound` directory
+* install and configuration are needed for `make test` to run
 
 ### **Configuration files**
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -47,8 +47,10 @@ class Capturing(list):
         return self
 
     def __exit__(self, *args):
+        self._stringio.write('EXCEPTION RAISED')
         self.extend(self._stringio.getvalue().splitlines())
         sys.stdout = self._stdout
+        return True  # Ignore any exception
 
 
 class TestAclhound(unittest.TestCase):
@@ -69,6 +71,7 @@ class TestAclhound(unittest.TestCase):
             cli.build({u'--help': False, u'--version': False, u'<devicename>':
                        'devices/s2-ios.meerval.net', u'<command>': 'build',
                        u'debug': False, u'jenkins': True})
+        self.assertNotIn('ERROR', '\n'.join(output))
         predefined_output = open('build_ios.txt').read().splitlines()
         # remove first line, as this contains system specific output
         output.pop(0)
@@ -88,6 +91,7 @@ class TestAclhound(unittest.TestCase):
             cli.build({u'--help': False, u'--version': False, u'<devicename>':
                        'devices/s2-asa.meerval.net', u'<command>': 'build',
                        u'debug': False, u'jenkins': True})
+        self.assertNotIn('ERROR', '\n'.join(output))
         predefined_output = open('build_asa.txt').read().splitlines()
         output.pop(0)
         predefined_output.pop(0)


### PR DESCRIPTION
Addresses https://github.com/job/aclhound/issues/53

When a fresh project is set up following the instructions at https://github.com/job/aclhound/blob/master/INSTALL-CONFIG.md, the tests currently fail.  The python setup and install have to be done before running the tests for them to actually complete.  This updates the docs so the tests actually run.

This PR also makes a small code change: currently, the `tests\test_regression.py` Capturing() class swallows exception input, making it difficult to diagnose issues; e.g.:

```
======================================================================
ERROR: test_01__build_ios (tests.test_regression.TestAclhound)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/jzohrab/Documents/Projects/aclhound/tests/test_regression.py", line 68, in test_01__build_ios
    u'debug': False, u'jenkins': True})
  File "/Users/jzohrab/Documents/Projects/aclhound/aclhound/cli.py", line 215, in __init__
    self._settings = Settings()
  File "/Users/jzohrab/Documents/Projects/aclhound/aclhound/cli.py", line 82, in __init__
    sys.exit(2)
SystemExit: 2
```

The code change prints out extra information:

```
======================================================================
FAIL: test_01__build_ios (tests.test_regression.TestAclhound)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/jzohrab/Documents/Projects/aclhound/tests/test_regression.py", line 74, in test_01__build_ios
    self.assertNotIn('ERROR', '\n'.join(output))
AssertionError: u'ERROR' unexpectedly found in u"ERROR: Whoops!\nERROR: ~/.aclhound/ does not exist yet\nHINT: possible config corruption, delete it and run 'aclhound init'\nEXCEPTION RAISED"
    """Fail immediately, with the given message."""
>>  raise self.failureException('u\'ERROR\' unexpectedly found in u"ERROR: Whoops!\\nERROR: ~/.aclhound/ does not exist yet\\nHINT: possible config corruption, delete it and run \'aclhound init\'\\nEXCEPTION RAISED"')
```

It's not *great* but at least it tells a bit more about the error that's happened.

Note that this is a misconfiguration error, so a user problem rather than a software problem, but a clearer error message doesn't hurt.

Note: the tests are currently failing, I'll raise another issue for this.